### PR TITLE
Fix numpy and Cython typing for numpy >= 1.25

### DIFF
--- a/CTL/causal_tree/util_c.pyx
+++ b/CTL/causal_tree/util_c.pyx
@@ -359,9 +359,9 @@ cpdef tau_squared_trigger(np.ndarray[np.float_t, ndim=1] y, np.ndarray[np.float_
     cdef np.ndarray[np.float_t, ndim=2] tt
     cdef np.ndarray x
 
-    cdef np.ndarray[np.long_t, ndim=1] treat_num
-    cdef np.ndarray[np.long_t, ndim=1] cont_num
-    cdef np.ndarray[np.long_t, ndim=1] min_size_idx
+    cdef np.ndarray[np.longlong_t, ndim=1] treat_num
+    cdef np.ndarray[np.longlong_t, ndim=1] cont_num
+    cdef np.ndarray[np.longlong_t, ndim=1] min_size_idx
 
     cdef np.ndarray[np.float_t, ndim=1] y_t_m
     cdef np.ndarray[np.float_t, ndim=1] y_c_m

--- a/CTL/causal_tree_learn.py
+++ b/CTL/causal_tree_learn.py
@@ -69,9 +69,9 @@ class CausalTree(_CausalTree):
 
     def fit(self, x, y, t):
         self.column_num = x.shape[1]
-        x = x.astype(np.float)
-        y = y.astype(np.float)
-        t = t.astype(np.float)
+        x = x.astype(np.float64)
+        y = y.astype(np.float64)
+        t = t.astype(np.float64)
         self.tree.fit(x, y, t)
         self.fitted = True
         self.tree_depth = self.tree.tree_depth

--- a/CTL/causal_tree_match.py
+++ b/CTL/causal_tree_match.py
@@ -17,9 +17,9 @@ class CausalTreeMatch:
 
     def fit(self, x, y, t):
         self.column_num = x.shape[1]
-        x = x.astype(np.float)
-        y = y.astype(np.float)
-        t = t.astype(np.float)
+        x = x.astype(np.float64)
+        y = y.astype(np.float64)
+        t = t.astype(np.float64)
         self.tree.fit(x, y, t)
         self.fitted = True
         self.tree_depth = self.tree.tree_depth

--- a/CTL/pehe_tree.py
+++ b/CTL/pehe_tree.py
@@ -42,9 +42,9 @@ class PEHETree(_CausalTree):
 
     def fit(self, x, y, t):
         self.column_num = x.shape[1]
-        x = x.astype(np.float)
-        y = y.astype(np.float)
-        t = t.astype(np.float)
+        x = x.astype(np.float64)
+        y = y.astype(np.float64)
+        t = t.astype(np.float64)
         self.tree.fit(x, y, t)
         self.fitted = True
         self.tree_depth = self.tree.tree_depth

--- a/CTL/sig_diff_tree.py
+++ b/CTL/sig_diff_tree.py
@@ -29,9 +29,9 @@ class SigDiffTree(_CausalTree):
 
     def fit(self, x, y, t):
         self.column_num = x.shape[1]
-        x = x.astype(np.float)
-        y = y.astype(np.float)
-        t = t.astype(np.float)
+        x = x.astype(np.float64)
+        y = y.astype(np.float64)
+        t = t.astype(np.float64)
         self.tree.fit(x, y, t)
         self.fitted = True
         self.tree_depth = self.tree.tree_depth

--- a/build/lib.macosx-12.6-arm64-cpython-310/CTL/causal_tree_learn.py
+++ b/build/lib.macosx-12.6-arm64-cpython-310/CTL/causal_tree_learn.py
@@ -69,9 +69,9 @@ class CausalTree(_CausalTree):
 
     def fit(self, x, y, t):
         self.column_num = x.shape[1]
-        x = x.astype(np.float)
-        y = y.astype(np.float)
-        t = t.astype(np.float)
+        x = x.astype(np.float64)
+        y = y.astype(np.float64)
+        t = t.astype(np.float64)
         self.tree.fit(x, y, t)
         self.fitted = True
         self.tree_depth = self.tree.tree_depth

--- a/build/lib.macosx-12.6-arm64-cpython-310/CTL/causal_tree_match.py
+++ b/build/lib.macosx-12.6-arm64-cpython-310/CTL/causal_tree_match.py
@@ -17,9 +17,9 @@ class CausalTreeMatch:
 
     def fit(self, x, y, t):
         self.column_num = x.shape[1]
-        x = x.astype(np.float)
-        y = y.astype(np.float)
-        t = t.astype(np.float)
+        x = x.astype(np.float64)
+        y = y.astype(np.float64)
+        t = t.astype(np.float64)
         self.tree.fit(x, y, t)
         self.fitted = True
         self.tree_depth = self.tree.tree_depth

--- a/build/lib.macosx-12.6-arm64-cpython-310/CTL/pehe_tree.py
+++ b/build/lib.macosx-12.6-arm64-cpython-310/CTL/pehe_tree.py
@@ -42,9 +42,9 @@ class PEHETree(_CausalTree):
 
     def fit(self, x, y, t):
         self.column_num = x.shape[1]
-        x = x.astype(np.float)
-        y = y.astype(np.float)
-        t = t.astype(np.float)
+        x = x.astype(np.float64)
+        y = y.astype(np.float64)
+        t = t.astype(np.float64)
         self.tree.fit(x, y, t)
         self.fitted = True
         self.tree_depth = self.tree.tree_depth

--- a/build/lib.macosx-12.6-arm64-cpython-310/CTL/sig_diff_tree.py
+++ b/build/lib.macosx-12.6-arm64-cpython-310/CTL/sig_diff_tree.py
@@ -29,9 +29,9 @@ class SigDiffTree(_CausalTree):
 
     def fit(self, x, y, t):
         self.column_num = x.shape[1]
-        x = x.astype(np.float)
-        y = y.astype(np.float)
-        t = t.astype(np.float)
+        x = x.astype(np.float64)
+        y = y.astype(np.float64)
+        t = t.astype(np.float64)
         self.tree.fit(x, y, t)
         self.fitted = True
         self.tree_depth = self.tree.tree_depth


### PR DESCRIPTION
With numpy 1.25, `long_t` and `ulong_t` are [no longer supported](https://numpy.org/doc/stable/release/1.25.0-notes.html#cython-long-t-and-ulong-t-removed). Fixing this issue here.

This also fixes manual install errors in #21 (may also fix the pip install issue as well)!